### PR TITLE
Added 'PATCH' to the list of calls for building the JmxBody.

### DIFF
--- a/src/main/java/com/loadium/postman2jmx/builder/JmxRawBodyBuilder.java
+++ b/src/main/java/com/loadium/postman2jmx/builder/JmxRawBodyBuilder.java
@@ -17,7 +17,7 @@ public class JmxRawBodyBuilder extends AbstractJmxBodyBuilder {
 
         HTTPSamplerProxy httpSamplerProxy = JmxHTTPSamplerProxy.newInstance(postmanItem);
 
-        if (HttpMethod.POST.equalsIgnoreCase(httpSamplerProxy.getMethod()) || HttpMethod.PUT.equalsIgnoreCase(httpSamplerProxy.getMethod()) || HttpMethod.DELETE.equalsIgnoreCase(httpSamplerProxy.getMethod())) {
+        if (HttpMethod.POST.equalsIgnoreCase(httpSamplerProxy.getMethod()) || HttpMethod.PUT.equalsIgnoreCase(httpSamplerProxy.getMethod()) || HttpMethod.DELETE.equalsIgnoreCase(httpSamplerProxy.getMethod()) || httpSamplerProxy.getMethod().equalsIgnoreCase("PATCH")) {
             httpSamplerProxy.setPostBodyRaw(true);
             Arguments arguments = new Arguments();
             PostmanRawBody raw = postmanItem.getRequest().getBody().getRaw();


### PR DESCRIPTION
* Body field can be populated for a PATCH call within Postman, which is not populated in the jmx file.
* Added 'PATCH' to the list of calls for building the JmxBody.
* PATCH constant is available within Java WS RS API v2.1. However, jMeter v4 refers to Java WS RS API v2.0.1 which does not have a PATCH constant.
* PR is related to this [issue](https://github.com/Loadium/postman2jmx/issues/9).